### PR TITLE
Api namespace

### DIFF
--- a/Nancy.Rollbar.Tests/FakePersonFactory.cs
+++ b/Nancy.Rollbar.Tests/FakePersonFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Nancy.Rollbar.Api;
 using Nancy.Security;
 using Valetude.Rollbar;
 

--- a/Nancy.Rollbar.Tests/RollbarPayloadFactoryFixture.cs
+++ b/Nancy.Rollbar.Tests/RollbarPayloadFactoryFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FakeItEasy;
 using FakeItEasy.ExtensionSyntax.Full;
+using Nancy.Rollbar.Api;
 using Nancy.Testing;
 using Valetude.Rollbar;
 using Xunit;

--- a/Nancy.Rollbar/Api/IHasAccessToken.cs
+++ b/Nancy.Rollbar/Api/IHasAccessToken.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.Rollbar {
+﻿namespace Nancy.Rollbar.Api {
     public interface IHasAccessToken {
         string RollbarAccessToken { get; }
     }

--- a/Nancy.Rollbar/Api/IPersonFactory.cs
+++ b/Nancy.Rollbar/Api/IPersonFactory.cs
@@ -1,7 +1,7 @@
 ﻿using Nancy.Security;
 using Valetude.Rollbar;
 
-namespace Nancy.Rollbar {
+namespace Nancy.Rollbar.Api {
     public interface IPersonFactory{
         RollbarPerson GetPerson(IUserIdentity currentUser);
     }

--- a/Nancy.Rollbar/Api/IRollbarDataFactory.cs
+++ b/Nancy.Rollbar/Api/IRollbarDataFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Valetude.Rollbar;
 
-namespace Nancy.Rollbar {
+namespace Nancy.Rollbar.Api {
     public interface IRollbarDataFactory {
         RollbarData GetData(NancyContext context, Exception exception);
     }

--- a/Nancy.Rollbar/Api/IRollbarPayloadFactory.cs
+++ b/Nancy.Rollbar/Api/IRollbarPayloadFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Valetude.Rollbar;
 
-namespace Nancy.Rollbar {
+namespace Nancy.Rollbar.Api {
     public interface IRollbarPayloadFactory {
         RollbarPayload GetPayload(NancyContext context, Exception e);
     }

--- a/Nancy.Rollbar/Api/IRollbarPayloadSender.cs
+++ b/Nancy.Rollbar/Api/IRollbarPayloadSender.cs
@@ -1,6 +1,6 @@
 ﻿using Valetude.Rollbar;
 
-namespace Nancy.Rollbar {
+namespace Nancy.Rollbar.Api {
     public interface IRollbarPayloadSender {
         RollbarResponse SendPayload(RollbarPayload payload);
     }

--- a/Nancy.Rollbar/Nancy.Rollbar.csproj
+++ b/Nancy.Rollbar/Nancy.Rollbar.csproj
@@ -57,11 +57,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="IHasAccessToken.cs" />
-    <Compile Include="IPersonFactory.cs" />
-    <Compile Include="IRollbarDataFactory.cs" />
-    <Compile Include="IRollbarPayloadFactory.cs" />
-    <Compile Include="IRollbarPayloadSender.cs" />
+    <Compile Include="Api\IHasAccessToken.cs" />
+    <Compile Include="Api\IPersonFactory.cs" />
+    <Compile Include="Api\IRollbarDataFactory.cs" />
+    <Compile Include="Api\IRollbarPayloadFactory.cs" />
+    <Compile Include="Api\IRollbarPayloadSender.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RollbarDataFactory.cs" />
     <Compile Include="RollbarPayloadFactory.cs" />

--- a/Nancy.Rollbar/Nancy.Rollbar.nuspec
+++ b/Nancy.Rollbar/Nancy.Rollbar.nuspec
@@ -4,7 +4,7 @@
     <id>$id$</id>
     <version>$version$</version>
     <title>Nancy.Rollbar</title>
-    <authors>Chris Pfohl</authors>
+    <authors>Chris Pfohl, Adam Elnagger</authors>
     <owners>Valetude LLC</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/Valetude/Nancy.Rollbar</projectUrl>

--- a/Nancy.Rollbar/Properties/AssemblyInfo.cs
+++ b/Nancy.Rollbar/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/Nancy.Rollbar/RollbarDataFactory.cs
+++ b/Nancy.Rollbar/RollbarDataFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Nancy.Extensions;
+using Nancy.Rollbar.Api;
 using Valetude.Rollbar;
 
 namespace Nancy.Rollbar {

--- a/Nancy.Rollbar/RollbarPayloadFactory.cs
+++ b/Nancy.Rollbar/RollbarPayloadFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Nancy.Rollbar.Api;
 using Valetude.Rollbar;
 
 namespace Nancy.Rollbar {

--- a/Nancy.Rollbar/RollbarPayloadSender.cs
+++ b/Nancy.Rollbar/RollbarPayloadSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using Nancy.Rollbar.Api;
 using Valetude.Rollbar;
 
 namespace Nancy.Rollbar {


### PR DESCRIPTION
Move all interfaces into an Api namespace. This is mostly for project housecleaning, so that all the files don't end up at the same base level.
